### PR TITLE
WIP: Annotator shortcuts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,5 +132,10 @@
 			<groupId>de.embl.cba</groupId>
 			<artifactId>imglib2-lazy-algorithm</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>de.embl.cba</groupId>
+			<artifactId>imglib2-lazy-algorithm</artifactId>
+			<version>0.2.2</version>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/de/embl/cba/tables/annotate/Annotator.java
+++ b/src/main/java/de/embl/cba/tables/annotate/Annotator.java
@@ -1,6 +1,7 @@
 package de.embl.cba.tables.annotate;
 
 import bdv.util.BdvHandle;
+import de.embl.cba.bdv.utils.BdvUtils;
 import de.embl.cba.bdv.utils.behaviour.BdvBehaviours;
 import de.embl.cba.tables.SwingUtils;
 import de.embl.cba.tables.TableRows;
@@ -10,6 +11,7 @@ import de.embl.cba.tables.select.SelectionModel;
 import de.embl.cba.tables.tablerow.TableRow;
 import ij.gui.GenericDialog;
 import net.imglib2.type.numeric.ARGBType;
+import org.scijava.ui.behaviour.ClickBehaviour;
 import org.scijava.ui.behaviour.util.Behaviours;
 import org.scijava.ui.behaviour.io.InputTriggerConfig;
 
@@ -96,7 +98,8 @@ public class Annotator < T extends TableRow > extends JFrame
             // - how do we get access to the current selection here
             // - maybe this needs to go t o'addAnnotationButtonPanel' instead ? 
 
-		    // BdvBehaviours.addViewCaptureBehaviour( bdv, behaviours, "C", false );
+		    // dummy
+			BdvBehaviours.addPositionAndViewLoggingBehaviour( bdv, behaviours, "K" );
         }
 	}
 

--- a/src/main/java/de/embl/cba/tables/annotate/Annotator.java
+++ b/src/main/java/de/embl/cba/tables/annotate/Annotator.java
@@ -26,7 +26,7 @@ public class Annotator < T extends TableRow > extends JFrame
 	private final SelectionModel< T > selectionModel;
 	private final CategoryTableRowColumnColoringModel< T > coloringModel;
 	private final JPanel panel;
-	private BdvHandle bdv;
+	private BdvHandle bdv = null;
 
 	public Annotator(
 			String annotationColumnName,
@@ -43,17 +43,14 @@ public class Annotator < T extends TableRow > extends JFrame
 		this.coloringModel = coloringModel;
 		coloringModel.fixedColorMode( true );
 		this.panel = new JPanel();
-		this.bdv = null;
-	}
-
-	public void setBdv(BdvHandle handle) {
-	{
-		this.bdv = handle;
 	}
 
 	public BdvHandle getBdv() {
-	{
-		return this.bdv;
+		return bdv;
+	}
+
+	public void setBdv(BdvHandle bdv) {
+		this.bdv = bdv;
 	}
 
 	public void showDialog()
@@ -96,7 +93,7 @@ public class Annotator < T extends TableRow > extends JFrame
             // TODO unclear to me:
             // - what is the correct behaviour? 'addViewCaptureBehaviour' does not sound right
             // - how do we get the current category id from the lambda passed to 'addActionListener' abvoe?
-            // - how do we get acceess to the current selection here
+            // - how do we get access to the current selection here
             // - maybe this needs to go t o'addAnnotationButtonPanel' instead ? 
 
 		    // BdvBehaviours.addViewCaptureBehaviour( bdv, behaviours, "C", false );

--- a/src/main/java/de/embl/cba/tables/annotate/Annotator.java
+++ b/src/main/java/de/embl/cba/tables/annotate/Annotator.java
@@ -1,5 +1,7 @@
 package de.embl.cba.tables.annotate;
 
+import bdv.util.BdvHandle;
+import de.embl.cba.bdv.utils.behaviour.BdvBehaviours;
 import de.embl.cba.tables.SwingUtils;
 import de.embl.cba.tables.TableRows;
 import de.embl.cba.tables.color.CategoryTableRowColumnColoringModel;
@@ -8,6 +10,8 @@ import de.embl.cba.tables.select.SelectionModel;
 import de.embl.cba.tables.tablerow.TableRow;
 import ij.gui.GenericDialog;
 import net.imglib2.type.numeric.ARGBType;
+import org.scijava.ui.behaviour.util.Behaviours;
+import org.scijava.ui.behaviour.io.InputTriggerConfig;
 
 import javax.swing.*;
 import java.awt.*;
@@ -22,6 +26,7 @@ public class Annotator < T extends TableRow > extends JFrame
 	private final SelectionModel< T > selectionModel;
 	private final CategoryTableRowColumnColoringModel< T > coloringModel;
 	private final JPanel panel;
+	private BdvHandle bdv;
 
 	public Annotator(
 			String annotationColumnName,
@@ -38,6 +43,17 @@ public class Annotator < T extends TableRow > extends JFrame
 		this.coloringModel = coloringModel;
 		coloringModel.fixedColorMode( true );
 		this.panel = new JPanel();
+		this.bdv = null;
+	}
+
+	public void setBdv(BdvHandle handle) {
+	{
+		this.bdv = handle;
+	}
+
+	public BdvHandle getBdv() {
+	{
+		return this.bdv;
 	}
 
 	public void showDialog()
@@ -70,6 +86,21 @@ public class Annotator < T extends TableRow > extends JFrame
 			addAnnotationButtonPanel( gd.getNextString(), null );
 			refreshDialog();
 		});
+
+        // if we have a bdv handle, set the bdv shortcut for the new label
+        if(this.bdv != null) {
+		    Behaviours behaviours = new Behaviours( new InputTriggerConfig() );
+		    behaviours.install( bdv.getTriggerbindings(), "behaviours" );
+            // add key binding that assigns the currently selected label to the
+            // to numerical category corresponding to input key (= 1, 2, 3, ..., 0 (equiv to None))
+            // TODO unclear to me:
+            // - what is the correct behaviour? 'addViewCaptureBehaviour' does not sound right
+            // - how do we get the current category id from the lambda passed to 'addActionListener' abvoe?
+            // - how do we get acceess to the current selection here
+            // - maybe this needs to go t o'addAnnotationButtonPanel' instead ? 
+
+		    // BdvBehaviours.addViewCaptureBehaviour( bdv, behaviours, "C", false );
+        }
 	}
 
 	private void addAnnotationButtons()

--- a/src/main/java/de/embl/cba/tables/view/TableRowsTableView.java
+++ b/src/main/java/de/embl/cba/tables/view/TableRowsTableView.java
@@ -1,6 +1,7 @@
 package de.embl.cba.tables.view;
 
 import bdv.tools.HelpDialog;
+import bdv.util.BdvHandle;
 import de.embl.cba.bdv.utils.lut.GlasbeyARGBLut;
 import de.embl.cba.tables.*;
 import de.embl.cba.tables.annotate.Annotator;
@@ -46,6 +47,8 @@ public class TableRowsTableView < T extends TableRow > extends JPanel
 	private String tablesDirectory = "";
 	private boolean isZeroTransparent;
 
+	private BdvHandle bdv;
+
 	public TableRowsTableView(
 			final List< T > tableRows,
 			final SelectionModel< T > selectionModel,
@@ -70,6 +73,18 @@ public class TableRowsTableView < T extends TableRow > extends JPanel
 
 		registerAsSelectionListener( selectionModel );
 		registerAsColoringListener( selectionColoringModel );
+
+		this.bdv = null;
+	}
+
+	public void setBdv(BdvHandle handle)
+	{
+		this.bdv = handle;
+	}
+
+	public BdvHandle getBdv()
+	{
+		return bdv;
 	}
 
 	public List< T > getTableRows()
@@ -484,6 +499,11 @@ public class TableRowsTableView < T extends TableRow > extends JPanel
 				selectionModel,
 				categoricalColoringModel
 		);
+
+        // pass on the bdv handle to the annotator if it is not null
+        if(this.bdv != null) {
+            annotator.setBdv( this.bdv );
+        }
 
 		annotator.showDialog();
 	}

--- a/src/main/java/de/embl/cba/tables/view/combined/SegmentsTableBdvAnd3dViews.java
+++ b/src/main/java/de/embl/cba/tables/view/combined/SegmentsTableBdvAnd3dViews.java
@@ -72,6 +72,7 @@ public class SegmentsTableBdvAnd3dViews
 				selectionColoringModel,
 				viewName );
 
+		tableRowsTableView.setBdv( bdv );
 		tableRowsTableView.setParentComponent( bdv.getViewerPanel() );
 
 		tableRowsTableView.showTableAndMenu();


### PR DESCRIPTION
I am trying to add shortcuts to the annotator for fast annotations.
The idea is to have the keys `1`, `2`, ..., `9` connected with the user created categories and `0` for `none`.

What I managed so far:
- add a bdv handle to the `Annotator` (if called from `SegmentsTableBdv3dView`)
- add a dummy positions shortcut that also works: https://github.com/constantinpape/table-utils/blob/annotator-shortcuts/src/main/java/de/embl/cba/tables/annotate/Annotator.java#L102

Now the question is how to adapt the shortcut so that it does what I want.
I already guess that it should be moved to here: https://github.com/constantinpape/table-utils/blob/annotator-shortcuts/src/main/java/de/embl/cba/tables/annotate/Annotator.java#L102
Any pointers are welcome.